### PR TITLE
feat: use !cancelled() instead of always()

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -10,7 +10,6 @@ on:
       - reopened
       - synchronize
 
-
 # https://docs.github.com/en/actions/using-jobs/using-concurrency https://stackoverflow.com/a/72408109/16358266
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -67,7 +66,7 @@ jobs:
   # This job does nothing and is only used for the branch protection
   all-required-green:
     name: Check if all required jobs succeeded
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - lint-repository-files
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-lint-files.yaml
+++ b/.github/workflows/reusable-lint-files.yaml
@@ -145,7 +145,7 @@ jobs:
 
   workflow-result-job:
     name: Determine the result of the workflow
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - lint-editorconfig-job
       - lint-github-actions-job


### PR DESCRIPTION
Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative: if: ${{ !cancelled() }}.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always