### PR TITLE
chore: fail_on_error is deprecated

### DIFF
--- a/.github/actions/github-workflows-lint/action.yaml
+++ b/.github/actions/github-workflows-lint/action.yaml
@@ -26,7 +26,7 @@ runs:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github-token }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:
-        fail_on_error: true
+        fail_level: any
         filter_mode: ${{ inputs.filter-mode }}
         level: error
         reporter: ${{ inputs.reporter }}


### PR DESCRIPTION
Replace fail_on_error with fail_level in reviewdog/action-actionlint